### PR TITLE
fix(changeLog): change log not added correctly

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -19,12 +19,14 @@ export const updateChangeLog = (newVersion: string, defaultChangelog = "") => {
     "Unreleased"
   ).trim();
 
+  const haveChangelog = Boolean(changelog && !changelog.includes('No unreleased changes.'))
+
   fs.writeFileSync(
     FILE_NAME,
     content.replace(
       /^##\s+Unreleased$/m,
       `## Unreleased\n\nNo unreleased changes.\n\n## ${newVersion}${
-        changelog ? "" : `\n\n${defaultChangelog}`
+        haveChangelog ? changelog : `\n\n${defaultChangelog}`
       }`
     ),
     "utf8"

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -26,7 +26,7 @@ export const updateChangeLog = (newVersion: string, defaultChangelog = "") => {
     content.replace(
       /^##\s+Unreleased$/m,
       `## Unreleased\n\nNo unreleased changes.\n\n## ${newVersion}${
-        haveChangelog ? changelog : `\n\n${defaultChangelog}`
+        haveChangelog ? "" : `\n\n${defaultChangelog}`
       }`
     ),
     "utf8"

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -17,18 +17,23 @@ export const updateChangeLog = (newVersion: string, defaultChangelog = "") => {
   const changelog = getSectionBelowHeadingInMarkdown(
     content,
     "Unreleased"
-  ).trim();
+  )
 
-  const haveChangelog = Boolean(changelog && !changelog.includes('No unreleased changes.'))
+  const haveChangelog = Boolean(changelog.trim() && !changelog.includes('No unreleased changes.'))
+
+  const newContent = haveChangelog
+    ? content.replace(
+      /^##\s+Unreleased$/m,
+      `## Unreleased\n\nNo unreleased changes.\n\n## ${newVersion}`
+    )
+    : content.replace(
+      /^##\s+Unreleased$\n(\S|\s)+?(?=^##)/m,
+      `## Unreleased\n\nNo unreleased changes.\n\n## ${newVersion}\n\n${defaultChangelog}\n\n`
+    )
 
   fs.writeFileSync(
     FILE_NAME,
-    content.replace(
-      /^##\s+Unreleased$/m,
-      `## Unreleased\n\nNo unreleased changes.\n\n## ${newVersion}${
-        haveChangelog ? "" : `\n\n${defaultChangelog}`
-      }`
-    ),
+    newContent,
     "utf8"
   );
 };


### PR DESCRIPTION
### BUG:

The change log is automatically generated the first time you use the `kanpai` command, but not the next time you use it again.
The `kanpai` command creates a `No unreleased changes.` as a pending release each time, and this default content in the original code is incorrectly recognized as a user-filled changelog at release time, resulting in the `defaultChangelog` not being automatically populated as a changelog.

### Desired effect:

The commit log can be filled automatically each time a tag is added with the `kanpai` command.
